### PR TITLE
Send metadata to Archiver

### DIFF
--- a/python/extractor.py
+++ b/python/extractor.py
@@ -147,6 +147,23 @@ def guardar_assets(rgba_img: np.ndarray, contornos: list, output_dir: str, style
         json.dump(metadata, jsonfile, ensure_ascii=False, indent=2)
 
     upload_to_supabase(json_path, "assets_metadata.json")
+
+    # Enviar metadata al servicio Archiver
+    try:
+        with open(json_path, "r") as f:
+            json_data = json.load(f)
+        resp = requests.post(
+            "https://archiver-vercel.vercel.app/api/archiver",
+            json=json_data,
+            timeout=10,
+        )
+        if resp.ok:
+            print("Archiver request successful")
+        else:
+            print(f"Archiver request failed: {resp.status_code} {resp.text}")
+    except Exception as e:
+        print(f"Error sending to Archiver: {e}")
+
     return metadata
 
 def upload_to_supabase(local_path, filename):


### PR DESCRIPTION
## Summary
- send generated `assets_metadata.json` to Archiver service after exporting assets

## Testing
- `python -m py_compile python/extractor.py`
- `python -m py_compile python/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6858a8cb071c8322a3735035bf463374